### PR TITLE
BUG: setuptools fails with ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 from setuptools import find_packages
 
-from fcdr_writer import FCDRWriter
+from fiduceo.fcdr.writer.fcdr_writer import FCDRWriter
 
 setup(name='fcdr_tools', version=FCDRWriter._version, description='FIDUCEO CDR/FCDR read and write utilities', author='Tom Block', author_email='tom.block@brockmann-consult.de',
       url='http://www.fiduceo.eu', packages=find_packages(), install_requires=['numpy', 'xarray', 'netcdf4'])


### PR DESCRIPTION
a fresh install of FCDRTools fails — the setup.py contains

from fcdr_writer import FCDRWriter

which leads to a ModuleNotFoundError (or ImportError on older Python)

this fixes the problem.