### PR TITLE
Rename random -> independent, non-random -> structured, as discussed

### DIFF
--- a/fiduceo/fcdr/test/writer/fcdr_writer_test.py
+++ b/fiduceo/fcdr/test/writer/fcdr_writer_test.py
@@ -190,8 +190,8 @@ class FCDRWriterTest(unittest.TestCase):
         self.assertIsNotNone(ds.variables["qualind"])
 
         # easy FCDR variables
-        self.assertIsNotNone(ds.variables["u_random"])
-        self.assertIsNotNone(ds.variables["u_non_random"])
+        self.assertIsNotNone(ds.variables["u_independent"])
+        self.assertIsNotNone(ds.variables["u_structured"])
 
     def testCreateTemplateFull_HIRS2(self):
         ds = FCDRWriter.createTemplateFull('HIRS2', 209)
@@ -290,8 +290,8 @@ class FCDRWriterTest(unittest.TestCase):
         self.assertIsNotNone(ds.variables["mnfrqualflags"])
 
         # easy FCDR variables
-        self.assertIsNotNone(ds.variables["u_random"])
-        self.assertIsNotNone(ds.variables["u_non_random"])
+        self.assertIsNotNone(ds.variables["u_independent"])
+        self.assertIsNotNone(ds.variables["u_structured"])
 
     def testCreateTemplateFull_HIRS3(self):
         ds = FCDRWriter.createTemplateFull('HIRS3', 209)
@@ -388,8 +388,8 @@ class FCDRWriterTest(unittest.TestCase):
         self.assertIsNotNone(ds.variables["mnfrqualflags"])
 
         # easy FCDR variables
-        self.assertIsNotNone(ds.variables["u_random"])
-        self.assertIsNotNone(ds.variables["u_non_random"])
+        self.assertIsNotNone(ds.variables["u_independent"])
+        self.assertIsNotNone(ds.variables["u_structured"])
 
     def testCreateTemplateFull_HIRS4(self):
         ds = FCDRWriter.createTemplateFull('HIRS4', 209)

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -127,16 +127,16 @@ class HIRS:
         default_array = DefaultData.create_default_array_3d(SWATH_WIDTH, height, NUM_CHANNELS, np.float32, np.NaN)
         variable = Variable(["channel", "y", "x"], default_array)
         tu.add_fill_value(variable, np.NaN)
-        variable.attrs["long_name"] = "random uncertainty per pixel"
-        tu.add_units(variable, "percent")
-        dataset["u_random"] = variable
+        variable.attrs["long_name"] = "independent uncertainty per pixel"
+        tu.add_units(variable, "K")
+        dataset["u_independent"] = variable
 
         default_array = DefaultData.create_default_array_3d(SWATH_WIDTH, height, NUM_CHANNELS, np.float32, np.NaN)
         variable = Variable(["channel", "y", "x"], default_array)
         tu.add_fill_value(variable, np.NaN)
-        variable.attrs["long_name"] = "non-random uncertainty per pixel"
-        tu.add_units(variable, "percent")
-        dataset["u_non_random"] = variable
+        variable.attrs["long_name"] = "structured uncertainty per pixel"
+        tu.add_units(variable, "K")
+        dataset["u_structured"] = variable
 
     @staticmethod
     def add_common_full_fcdr_variables(dataset, height):


### PR DESCRIPTION
This was discussed during the FIDUCEO meeting in Brussels in September.  Should probably do the same for the other sensors.