### PR TITLE
AVHRR changed reflectance channel uncertainty units

### DIFF
--- a/fiduceo/fcdr/test/writer/templates/avhrr_test.py
+++ b/fiduceo/fcdr/test/writer/templates/avhrr_test.py
@@ -16,7 +16,7 @@ class AVHRRTest(unittest.TestCase):
         Assertions.assert_geolocation_variables(self, ds, 409, 5)
         Assertions.assert_quality_flags(self, ds, 409, 5)
 
-        time = ds.variables["Time"]
+        time = ds.variables["time"]
         self.assertEqual((5,), time.shape)
         self.assertTrue(np.isnan(time.data[2]))
         self.assertTrue(np.isnan(time.attrs["_FillValue"]))
@@ -73,12 +73,12 @@ class AVHRRTest(unittest.TestCase):
         ds = xr.Dataset()
         AVHRR.add_easy_fcdr_variables(ds, 5)
 
-        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch1", long_name="independent uncertainty per pixel for channel 1", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch1", long_name="structured uncertainty per pixel for channel 1", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch2", long_name="independent uncertainty per pixel for channel 2", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch2", long_name="structured uncertainty per pixel for channel 2", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch3a", long_name="independent uncertainty per pixel for channel 3a", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch3a", long_name="structured uncertainty per pixel for channel 3a", units="percent")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch1", long_name="independent uncertainty per pixel for channel 1", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch1", long_name="structured uncertainty per pixel for channel 1", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch2", long_name="independent uncertainty per pixel for channel 2", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch2", long_name="structured uncertainty per pixel for channel 2", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_independent_Ch3a", long_name="independent uncertainty per pixel for channel 3a", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "u_structured_Ch3a", long_name="structured uncertainty per pixel for channel 3a", units="1")
 
         self._assert_correct_bt_uncertainty_variable(ds, "u_independent_Ch3b", long_name="independent uncertainty per pixel for channel 3b")
         self._assert_correct_bt_uncertainty_variable(ds, "u_structured_Ch3b", long_name="structured uncertainty per pixel for channel 3b")
@@ -227,9 +227,9 @@ class AVHRRTest(unittest.TestCase):
         self._assert_correct_counts_uncertainty_variable(ds, "Ch5_u_Ce", "Ch5 Uncertainty on earth counts")
         self._assert_earth_counts_pdf(ds, "Ch5_u_Ce")
 
-        self._assert_correct_refl_uncertainty_variable(ds, "Ch1_u_Refl", long_name="Ch1 Total uncertainty on toa reflectance", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "Ch2_u_Refl", long_name="Ch2 Total uncertainty on toa reflectance", units="percent")
-        self._assert_correct_refl_uncertainty_variable(ds, "Ch3a_u_Refl", long_name="Ch3a Total uncertainty on toa reflectance", units="percent")
+        self._assert_correct_refl_uncertainty_variable(ds, "Ch1_u_Refl", long_name="Ch1 Total uncertainty on toa reflectance", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "Ch2_u_Refl", long_name="Ch2 Total uncertainty on toa reflectance", units="1")
+        self._assert_correct_refl_uncertainty_variable(ds, "Ch3a_u_Refl", long_name="Ch3a Total uncertainty on toa reflectance", units="1")
 
         self._assert_correct_bt_uncertainty_variable(ds, "Ch3b_u_Bt", long_name="Ch3b Total uncertainty on brightness temperature")
         self._assert_correct_bt_uncertainty_variable(ds, "Ch4_u_Bt", long_name="Ch4 Total uncertainty on brightness temperature")

--- a/fiduceo/fcdr/writer/templates/avhrr.py
+++ b/fiduceo/fcdr/writer/templates/avhrr.py
@@ -19,14 +19,14 @@ class AVHRR:
         tu.add_geolocation_variables(dataset, SWATH_WIDTH, height)
         tu.add_quality_flags(dataset, SWATH_WIDTH, height)
 
-        # Time
+        # time
         default_array = DefaultData.create_default_vector(height, np.float64, fill_value=np.NaN)
         variable = Variable(["y"], default_array)
         tu.add_fill_value(variable, np.NaN)
         tu.add_units(variable, "s")
         variable.attrs["standard_name"] = "time"
         variable.attrs["long_name"] = "Acquisition time in seconds since 1970-01-01 00:00:00"
-        dataset["Time"] = variable
+        dataset["time"] = variable
 
         # relative_azimuth_angle
         default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.float32, fill_value=np.NaN)
@@ -308,7 +308,7 @@ class AVHRR:
         default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.float32, fill_value=np.NaN)
         variable = Variable(["y", "x"], default_array)
 
-        tu.add_units(variable, "percent")
+        tu.add_units(variable, "1")
         variable.attrs["long_name"] = long_name
 
         if structured:


### PR DESCRIPTION
AVHRR changed reflectance channel uncertainty units from "percent" to "1" and changed "Time" to "time"