### PR TITLE
HIRS format and flags changes

### DIFF
--- a/fiduceo/fcdr/test/read_write/hirs_easy_iotest.py
+++ b/fiduceo/fcdr/test/read_write/hirs_easy_iotest.py
@@ -289,7 +289,7 @@ class HirsEASYIoTest(unittest.TestCase):
             hirs_easy["bt"].data[:, :, x] = np.ones((944), np.int16) * x * 0.01
             hirs_easy["latitude"].data[:, x] = np.ones((944), np.int16) * x * 0.02
             hirs_easy["longitude"].data[:, x] = np.ones((944), np.int16) * x * 0.03
-            hirs_easy["data_quality_bitmask"].data[:, x] = np.ones((944), np.int8) * x
+            hirs_easy["data_quality_bitmask"].data[:, :, x] = np.ones((944), np.int8) * x
             hirs_easy["quality_pixel_bitmask"].data[:, x] = np.ones((944), np.int8) * x
             if type != "HIRS2":
                 hirs_easy["satellite_zenith_angle"].data[:, x] = np.ones((944), np.int16) * x * 0.04

--- a/fiduceo/fcdr/test/writer/templates/hirs_assert.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_assert.py
@@ -103,9 +103,9 @@ class HIRSAssert(unittest.TestCase):
         dq_bitmask = ds.variables["data_quality_bitmask"]
         self.assertEqual((6, 56), dq_bitmask.shape)
         self.assertEqual(0, dq_bitmask.data[0, 5])
-        self.assertEqual("1, 2, 4, 8, 16", dq_bitmask.attrs["flag_masks"])
+        self.assertEqual("1, 2, 4", dq_bitmask.attrs["flag_masks"])
         self.assertEqual(
-            "suspect_mirror suspect_geo suspect_time outlier_nos uncertainty_too_large",
+            "suspect_mirror outlier_nos uncertainty_too_large",
             dq_bitmask.attrs["flag_meanings"])
         self.assertEqual("status_flag", dq_bitmask.attrs["standard_name"])
         self.assertEqual("longitude latitude", dq_bitmask.attrs["coordinates"])
@@ -113,10 +113,10 @@ class HIRSAssert(unittest.TestCase):
         qual_scan_bitmask = ds.variables["quality_scanline_bitmask"]
         self.assertEqual((6,), qual_scan_bitmask.shape)
         self.assertEqual(0, qual_scan_bitmask.data[5])
-        self.assertEqual("1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824",
+        self.assertEqual("1, 2, 4, 8, 16",
                          qual_scan_bitmask.attrs["flag_masks"])
         self.assertEqual(
-            "do_not_use_scan time_sequence_error data_gap_preceding_scan no_calibration no_earth_location clock_update status_changed line_incomplete, time_field_bad time_field_bad_not_inf inconsistent_sequence scan_time_repeat uncalib_bad_time calib_few_scans uncalib_bad_prt calib_marginal_prt uncalib_channels uncalib_inst_mode quest_ant_black_body zero_loc bad_loc_time bad_loc_marginal bad_loc_reason bad_loc_ant reduced_context bad_temp_no_rself",
+            "do_not_use_scan reduced_context bad_temp_no_rself suspect_geo suspect_time",
             qual_scan_bitmask.attrs["flag_meanings"])
         self.assertEqual("status_flag", qual_scan_bitmask.attrs["standard_name"])
         self.assertEqual("quality_indicator_bitfield", qual_scan_bitmask.attrs["long_name"])

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -34,8 +34,8 @@ class HIRS:
 
         default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.uint16, fill_value=0)
         variable = Variable(["y", "x"], default_array)
-        variable.attrs["flag_masks"] = "1, 2, 4, 8, 16"
-        variable.attrs["flag_meanings"] = "suspect_mirror suspect_geo suspect_time outlier_nos uncertainty_too_large"
+        variable.attrs["flag_masks"] = "1, 2, 4"
+        variable.attrs["flag_meanings"] = "suspect_mirror outlier_nos uncertainty_too_large"
         variable.attrs["standard_name"] = "status_flag"
         tu.add_chunking(variable, CHUNKING_2D)
         tu.add_geolocation_attribute(variable)
@@ -75,9 +75,9 @@ class HIRS:
         variable.attrs["standard_name"] = "status_flag"
         variable.attrs["long_name"] = "quality_indicator_bitfield"
         variable.attrs[
-            "flag_masks"] = "1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824"
+            "flag_masks"] = "1, 2, 4, 8, 16"
         variable.attrs[
-            "flag_meanings"] = "do_not_use_scan time_sequence_error data_gap_preceding_scan no_calibration no_earth_location clock_update status_changed line_incomplete, time_field_bad time_field_bad_not_inf inconsistent_sequence scan_time_repeat uncalib_bad_time calib_few_scans uncalib_bad_prt calib_marginal_prt uncalib_channels uncalib_inst_mode quest_ant_black_body zero_loc bad_loc_time bad_loc_marginal bad_loc_reason bad_loc_ant reduced_context bad_temp_no_rself"
+            "flag_meanings"] = "do_not_use_scan reduced_context bad_temp_no_rself suspect_geo suspect_time" 
         dataset["quality_scanline_bitmask"] = variable
 
         default_array = DefaultData.create_default_array(srf_size, NUM_CHANNELS, np.float32, fill_value=np.NaN)

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -33,7 +33,7 @@ class HIRS:
         tu.add_quality_flags(dataset, SWATH_WIDTH, height, chunksizes=CHUNKING_2D)
 
         default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.uint16, fill_value=0)
-        variable = Variable(["y", "x"], default_array)
+        variable = Variable(["y", "x", "channel"], default_array)
         variable.attrs["flag_masks"] = "1, 2, 4"
         variable.attrs["flag_meanings"] = "suspect_mirror outlier_nos uncertainty_too_large"
         variable.attrs["standard_name"] = "status_flag"

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -32,8 +32,8 @@ class HIRS:
     def add_quality_flags(dataset, height):
         tu.add_quality_flags(dataset, SWATH_WIDTH, height, chunksizes=CHUNKING_2D)
 
-        default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.uint16, fill_value=0)
-        variable = Variable(["y", "x", "channel"], default_array)
+        default_array = DefaultData.create_default_array_3d(SWATH_WIDTH, height, NUM_CHANNELS, np.uint16, fill_value=0)
+        variable = Variable(["channel", "y", "x"], default_array)
         variable.attrs["flag_masks"] = "1, 2, 4"
         variable.attrs["flag_meanings"] = "suspect_mirror outlier_nos uncertainty_too_large"
         variable.attrs["standard_name"] = "status_flag"

--- a/fiduceo/fcdr/writer/templates/hirs_flag_mapper.py
+++ b/fiduceo/fcdr/writer/templates/hirs_flag_mapper.py
@@ -13,8 +13,8 @@ class HIRS_FlagMapper(DefaultFlagMapper):
     UNCERTAINTY_TOO_LARGE = np.uint8(16)
 
     # scanline_quality
-    REDUCED_CONTEXT = np.int32(536870912)
-    BAD_TEMP_NO_RSELF = np.int32(1073741824)
+    REDUCED_CONTEXT = np.int32(2)
+    BAD_TEMP_NO_RSELF = np.int32(4)
 
     # channel_quality
     DO_NOT_USE = np.uint8(1)


### PR DESCRIPTION
Various changes to HIRS format and flags:

- [x] Removed HIRS flags that are only relevant for full FCDR, not easy FCDR
- [x] Moved HIRS flags from per-pixel to per-line where only relevant per line.
- [ ] Made sure all easyFCDR HIRSes have same format with all angles per pixel; differences should only exist for fullFCDR.