### PR TITLE
Remove HIRS flag values that are only relevant for full, not easy

### DIFF
--- a/fiduceo/fcdr/test/writer/templates/hirs_assert.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_assert.py
@@ -103,9 +103,9 @@ class HIRSAssert(unittest.TestCase):
         dq_bitmask = ds.variables["data_quality_bitmask"]
         self.assertEqual((6, 56), dq_bitmask.shape)
         self.assertEqual(0, dq_bitmask.data[0, 5])
-        self.assertEqual("1, 2, 4, 8, 16", dq_bitmask.attrs["flag_masks"])
+        self.assertEqual("1, 2, 4", dq_bitmask.attrs["flag_masks"])
         self.assertEqual(
-            "suspect_mirror suspect_geo suspect_time outlier_nos uncertainty_too_large",
+            "suspect_mirror outlier_nos uncertainty_too_large",
             dq_bitmask.attrs["flag_meanings"])
         self.assertEqual("status_flag", dq_bitmask.attrs["standard_name"])
         self.assertEqual("longitude latitude", dq_bitmask.attrs["coordinates"])
@@ -113,10 +113,10 @@ class HIRSAssert(unittest.TestCase):
         qual_scan_bitmask = ds.variables["quality_scanline_bitmask"]
         self.assertEqual((6,), qual_scan_bitmask.shape)
         self.assertEqual(0, qual_scan_bitmask.data[5])
-        self.assertEqual("1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824",
+        self.assertEqual("1, 2, 4, 8, 16",
                          qual_scan_bitmask.attrs["flag_masks"])
         self.assertEqual(
-            "do_not_use_scan time_sequence_error data_gap_preceding_scan no_calibration no_earth_location clock_update status_changed line_incomplete, time_field_bad time_field_bad_not_inf inconsistent_sequence scan_time_repeat uncalib_bad_time calib_few_scans uncalib_bad_prt calib_marginal_prt uncalib_channels uncalib_inst_mode quest_ant_black_body zero_loc bad_loc_time bad_loc_marginal bad_loc_reason bad_loc_ant reduced_context bad_temp_no_rself",
+            "do_not_use_scan reduced_context bad_temp_no_rself suspect_geo suspect_time",
             qual_scan_bitmask.attrs["flag_meanings"])
         self.assertEqual("status_flag", qual_scan_bitmask.attrs["standard_name"])
         self.assertEqual("quality_indicator_bitfield", qual_scan_bitmask.attrs["long_name"])

--- a/fiduceo/fcdr/test/writer/templates/hirs_flag_mapper_test.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_flag_mapper_test.py
@@ -61,7 +61,7 @@ class HIRS_FlagMapperTest(unittest.TestCase):
         self.dataset["quality_pixel_bitmask"].data[2, 0] = gf.INCOMPLETE_CHANNEL_DATA
         self.dataset["quality_pixel_bitmask"].data[0, 0] = gf.PADDED_DATA
 
-        self.dataset["quality_scanline_bitmask"].data[1] = 536870912  # reduced_context
+        self.dataset["quality_scanline_bitmask"].data[1] = 2  # reduced_context
 
         self.mapper.map_global_flags(self.dataset)
 
@@ -75,7 +75,7 @@ class HIRS_FlagMapperTest(unittest.TestCase):
         self.dataset["quality_pixel_bitmask"].data[0, 1] = gf.PADDED_DATA
         self.dataset["quality_pixel_bitmask"].data[1, 2] = gf.SENSOR_ERROR
 
-        self.dataset["quality_scanline_bitmask"].data[1] = 1073741824  # bad_temp_no_rself
+        self.dataset["quality_scanline_bitmask"].data[1] = 4  # bad_temp_no_rself
 
         self.mapper.map_global_flags(self.dataset)
 
@@ -135,7 +135,7 @@ class HIRS_FlagMapperTest(unittest.TestCase):
 
         self.dataset["quality_channel_bitmask"].data[1, :] = 2  # uncertainty_suspicious in all channels
 
-        self.dataset["quality_scanline_bitmask"].data[0] = 536870912  # reduced_context
+        self.dataset["quality_scanline_bitmask"].data[0] = 2  # reduced_context
 
         self.mapper.map_global_flags(self.dataset)
 

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -34,8 +34,8 @@ class HIRS:
 
         default_array = DefaultData.create_default_array(SWATH_WIDTH, height, np.uint16, fill_value=0)
         variable = Variable(["y", "x"], default_array)
-        variable.attrs["flag_masks"] = "1, 2, 4, 8, 16"
-        variable.attrs["flag_meanings"] = "suspect_mirror suspect_geo suspect_time outlier_nos uncertainty_too_large"
+        variable.attrs["flag_masks"] = "1, 2, 4"
+        variable.attrs["flag_meanings"] = "suspect_mirror outlier_nos uncertainty_too_large"
         variable.attrs["standard_name"] = "status_flag"
         tu.add_chunking(variable, CHUNKING_2D)
         tu.add_geolocation_attribute(variable)
@@ -75,9 +75,9 @@ class HIRS:
         variable.attrs["standard_name"] = "status_flag"
         variable.attrs["long_name"] = "quality_indicator_bitfield"
         variable.attrs[
-            "flag_masks"] = "1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456, 536870912, 1073741824"
+            "flag_masks"] = "1, 2, 4, 8, 16"
         variable.attrs[
-            "flag_meanings"] = "do_not_use_scan time_sequence_error data_gap_preceding_scan no_calibration no_earth_location clock_update status_changed line_incomplete, time_field_bad time_field_bad_not_inf inconsistent_sequence scan_time_repeat uncalib_bad_time calib_few_scans uncalib_bad_prt calib_marginal_prt uncalib_channels uncalib_inst_mode quest_ant_black_body zero_loc bad_loc_time bad_loc_marginal bad_loc_reason bad_loc_ant reduced_context bad_temp_no_rself"
+            "flag_meanings"] = "do_not_use_scan reduced_context bad_temp_no_rself suspect_geo suspect_time" 
         dataset["quality_scanline_bitmask"] = variable
 
         default_array = DefaultData.create_default_array(srf_size, NUM_CHANNELS, np.float32, fill_value=np.NaN)

--- a/fiduceo/fcdr/writer/templates/hirs_flag_mapper.py
+++ b/fiduceo/fcdr/writer/templates/hirs_flag_mapper.py
@@ -13,8 +13,8 @@ class HIRS_FlagMapper(DefaultFlagMapper):
     UNCERTAINTY_TOO_LARGE = np.uint8(16)
 
     # scanline_quality
-    REDUCED_CONTEXT = np.int32(536870912)
-    BAD_TEMP_NO_RSELF = np.int32(1073741824)
+    REDUCED_CONTEXT = np.int32(2)
+    BAD_TEMP_NO_RSELF = np.int32(4)
 
     # channel_quality
     DO_NOT_USE = np.uint8(1)


### PR DESCRIPTION
Some HIRS flag values are only relevant for full, not easy.

This pull request simply removes those flags, reassigning the corresponding flag values.

@TomBlock Is there a mechanism for flags to exist in the full but not in the easyFCDR, or should those flags then be in different fields?  In case of the latter, I'd propose to copy over the L1B fields as they are, which I think we already have in the full HIRS FCDR anyway, so then we don't need to explicitly list those full-only flags in FCDR-generated fields.