### PR TITLE
HIRS/2 now provides full angles

### DIFF
--- a/fiduceo/fcdr/test/writer/fcdr_writer_test.py
+++ b/fiduceo/fcdr/test/writer/fcdr_writer_test.py
@@ -225,7 +225,7 @@ class FCDRWriterTest(unittest.TestCase):
 
         Assertions.assert_global_attributes(self, ds.attrs)
 
-        self.assertEqual(19, len(ds.data_vars))
+        self.assertEqual(21, len(ds.data_vars))
 
         # geolocation + flags
         self._verify_geolocation_variables(ds)
@@ -252,7 +252,7 @@ class FCDRWriterTest(unittest.TestCase):
 
         Assertions.assert_global_attributes(self, ds.attrs)
 
-        self.assertEqual(95, len(ds.data_vars))
+        self.assertEqual(97, len(ds.data_vars))
 
         # geolocation + flags
         self._verify_geolocation_variables(ds)

--- a/fiduceo/fcdr/test/writer/templates/hirs_2_test.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_2_test.py
@@ -23,7 +23,7 @@ class HIRS2Test(unittest.TestCase):
         Assertions.assert_quality_flags(self, ds, 56, 6, chunking=CHUNKING_2D)
 
         ha.assert_bt_variable(ds, chunking=CHUNKING_3D)
-        self._assert_angle_variables(ds)
+        ha.assert_common_angles(ds, chunking=CHUNKING_2D)
         ha.assert_common_sensor_variables(ds, 102)
         ha.assert_coordinates(ds)
 
@@ -54,27 +54,3 @@ class HIRS2Test(unittest.TestCase):
         HIRS2.add_template_key(ds)
 
         self.assertEqual("HIRS2", ds.attrs["template_key"])
-
-    def _assert_angle_variables(self, ds):
-        satellite_zenith_angle = ds.variables["satellite_zenith_angle"]
-        self.assertEqual((6,), satellite_zenith_angle.shape)
-        self.assertTrue(np.isnan(satellite_zenith_angle.data[3]))
-        self.assertEqual(np.uint16, satellite_zenith_angle.encoding['dtype'])
-        self.assertEqual(DefaultData.get_default_fill_value(np.uint16), satellite_zenith_angle.encoding['_FillValue'])
-        self.assertEqual(0.01, satellite_zenith_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, satellite_zenith_angle.encoding['add_offset'])
-        self.assertEqual("platform_zenith_angle", satellite_zenith_angle.attrs["standard_name"])
-        self.assertEqual("degree", satellite_zenith_angle.attrs["units"])
-        self.assertEqual("longitude latitude", satellite_zenith_angle.attrs["coordinates"])
-
-        solar_azimuth_angle = ds.variables["solar_azimuth_angle"]
-        self.assertEqual((6, 56), solar_azimuth_angle.shape)
-        self.assertTrue(np.isnan(solar_azimuth_angle.data[4, 4]))
-        self.assertEqual(np.uint16, solar_azimuth_angle.encoding['dtype'])
-        self.assertEqual(DefaultData.get_default_fill_value(np.uint16), solar_azimuth_angle.encoding['_FillValue'])
-        self.assertEqual(0.01, solar_azimuth_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, solar_azimuth_angle.encoding['add_offset'])
-        self.assertEqual(CHUNKING_2D, solar_azimuth_angle.encoding['chunksizes'])
-        self.assertEqual("solar_azimuth_angle", solar_azimuth_angle.attrs["standard_name"])
-        self.assertEqual("degree", solar_azimuth_angle.attrs["units"])
-        self.assertEqual("longitude latitude", solar_azimuth_angle.attrs["coordinates"])

--- a/fiduceo/fcdr/writer/templates/hirs_2.py
+++ b/fiduceo/fcdr/writer/templates/hirs_2.py
@@ -15,7 +15,7 @@ class HIRS2(HIRS):
         HIRS.add_quality_flags(dataset, height)
 
         HIRS.add_bt_variable(dataset, height)
-        HIRS2._add_angle_variables(dataset, height)
+        HIRS.add_common_angles(dataset, height)
 
         if srf_size is None:
             srf_size = MAX_SRF_SIZE
@@ -38,15 +38,3 @@ class HIRS2(HIRS):
     @staticmethod
     def add_template_key(dataset):
         dataset.attrs["template_key"] = "HIRS2"
-
-    @staticmethod
-    def _add_angle_variables(dataset, height):
-        default_array = DefaultData.create_default_vector(height, np.float32, fill_value=np.NaN)
-        variable = Variable(["y"], default_array)
-        variable.attrs["standard_name"] = "platform_zenith_angle"
-        tu.add_units(variable, "degree")
-        tu.add_geolocation_attribute(variable)
-        tu.add_encoding(variable, np.uint16, DefaultData.get_default_fill_value(np.uint16), 0.01, -180.0)
-        dataset["satellite_zenith_angle"] = variable
-
-        dataset["solar_azimuth_angle"] = HIRS._create_geo_angle_variable("solar_azimuth_angle", height, chunking=CHUNKING_2D)


### PR DESCRIPTION
Adapted template and test cases to account for the fact that the HIRS/2
FCDR now includes full angles for all HIRS: solar azimuth/zenith,
satellite azimuth/zenith, same as for HIRS/3 and HIRS/4.