### PR TITLE
Enforce platform and sensor to be uppercase

### DIFF
--- a/fiduceo/fcdr/test/writer/fcdr_writer_test.py
+++ b/fiduceo/fcdr/test/writer/fcdr_writer_test.py
@@ -611,6 +611,7 @@ class FCDRWriterTest(unittest.TestCase):
         start = datetime.datetime(2014, 7, 22, 13, 23, 51)
         end = datetime.datetime(2014, 7, 22, 14, 24, 52)
         self.assertEqual("FIDUCEO_FCDR_L1C_HIRS3_NOAA15_20140722132351_20140722142452_EASY_v03.4_fv2.0.0.nc", FCDRWriter.create_file_name_FCDR_easy("HIRS3", "NOAA15", start, end, "03.4"))
+        self.assertEqual("FIDUCEO_FCDR_L1C_HIRS3_NOAA15_20140722132351_20140722142452_EASY_v03.4_fv2.0.0.nc", FCDRWriter.create_file_name_FCDR_easy("hirs3", "noaa15", start, end, "03.4"))
 
         start = datetime.datetime(2013, 6, 21, 12, 23, 50)
         end = datetime.datetime(2013, 6, 21, 13, 23, 51)

--- a/fiduceo/fcdr/writer/fcdr_writer.py
+++ b/fiduceo/fcdr/writer/fcdr_writer.py
@@ -120,4 +120,4 @@ class FCDRWriter:
     def _create_file_name(end, platform, sensor, start, type, version):
         start_string = start.strftime(DATE_PATTERN)
         end_string = end.strftime(DATE_PATTERN)
-        return "FIDUCEO_FCDR_L1C_" + sensor + "_" + platform + "_" + start_string + "_" + end_string + "_" + type + "_v" + version + "_fv" + __version__ + ".nc"
+        return "FIDUCEO_FCDR_L1C_" + sensor.upper() + "_" + platform.upper() + "_" + start_string + "_" + end_string + "_" + type + "_v" + version + "_fv" + __version__ + ".nc"


### PR DESCRIPTION
The writer now enforces that sensor and platform should be in UPPERCASE,
as specified in the file format specification.  Any lowercase or Mixed
Case sensor or platform names will be converted to uppercase.