### PR TITLE
Improve HIRS time precision

### DIFF
--- a/fiduceo/fcdr/test/writer/templates/hirs_assert.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_assert.py
@@ -92,11 +92,10 @@ class HIRSAssert(unittest.TestCase):
 
         time = ds.variables["time"]
         self.assertEqual((6,), time.shape)
-        self.assertEqual(DefaultData.get_default_fill_value(np.uint32), time.data[4])
-        self.assertEqual(DefaultData.get_default_fill_value(np.uint32), time.attrs["_FillValue"])
+        self.assertEqual(np.datetime64('NaT'), time.data[4])
+        self.assertEqual(4294967295, time.attrs["_FillValue"])
         self.assertEqual("time", time.attrs["standard_name"])
         self.assertEqual("Acquisition time in seconds since 1970-01-01 00:00:00", time.attrs["long_name"])
-        self.assertEqual("s", time.attrs["units"])
 
         dq_bitmask = ds.variables["data_quality_bitmask"]
         self.assertEqual((6, 56), dq_bitmask.shape)
@@ -179,7 +178,7 @@ class HIRSAssert(unittest.TestCase):
 
         channel = ds.coords["channel"]
         self.assertEqual((19,), channel.shape)
-        self.assertEqual("Ch7", channel[6])
+        self.assertEqual(7, channel[6])
 
     def _assert_3d_channel_variable(self, ds, name, long_name, chunking=None):
         variable = ds.variables[name]

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -149,11 +149,7 @@ class HIRS:
 
     @staticmethod
     def add_coordinates(dataset):
-        channel_names = []
-        for i in range(1, 20):
-            channel_names.append("Ch" + str(i))
-
-        tu.add_coordinates(dataset, channel_names)
+        tu.add_coordinates(dataset, np.arange(1, 20))
 
     @staticmethod
     def get_swath_width():

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -76,12 +76,13 @@ class HIRS:
         tu.add_units(variable, "count")
         dataset["scanline"] = variable
         # time
-        default_array = DefaultData.create_default_vector(height, np.uint32)
+        default_array = DefaultData.create_default_vector(height, np.datetime64)
         variable = Variable(["y"], default_array)
-        tu.add_fill_value(variable, DefaultData.get_default_fill_value(np.uint32))
+        tu.add_fill_value(variable, 4294967295)
         variable.attrs["standard_name"] = "time"
         variable.attrs["long_name"] = "Acquisition time in seconds since 1970-01-01 00:00:00"
-        tu.add_units(variable, "s")
+        tu.add_units(variable, "seconds since 1970-01-01 00:00:00")
+        tu.add_encoding(variable, np.uint32, 4294967295, scale_factor=0.1)
         dataset["time"] = variable
         # quality_scanline_bitmask
         default_array = DefaultData.create_default_vector(height, np.int32, fill_value=0)

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -81,8 +81,11 @@ class HIRS:
         tu.add_fill_value(variable, 4294967295)
         variable.attrs["standard_name"] = "time"
         variable.attrs["long_name"] = "Acquisition time in seconds since 1970-01-01 00:00:00"
-        tu.add_units(variable, "seconds since 1970-01-01 00:00:00")
+        # do not set 'units' here, xarray sets this from encoding upon storing the file
         tu.add_encoding(variable, np.uint32, 4294967295, scale_factor=0.1)
+        variable.encoding["units"] = "seconds since 1970-01-01 00:00:00"
+        # encoding 'add_offset' varies per file and either needs to be set
+        # by the user or intelligently in fiduceo.fcdr.writer.fcdr_writer.FCDRWriter.write
         dataset["time"] = variable
         # quality_scanline_bitmask
         default_array = DefaultData.create_default_vector(height, np.int32, fill_value=0)


### PR DESCRIPTION
Store HIRS time with a precision of 0.1 second rather than 1 second.  The template factory now returns time as a 'datetime64' dtype, so that the user can add actual times in there more easily.  It is still stored as uint32, as described by the encoding attribute.  The unit is now CF-compliant and in the encoding attribute, xarray puts it in the attributes as required.  It is still up to the user to add an add_offset such that the timespan for an orbit actually fits.  Ultimately it should be possible for FCDRTools to do the latter automatically, but then it should be part of the writing process (when the time span is actually known).  I guess the latter could be part of a routine that also adds global attributes describing the time span.

I intend to still push some more commits to this PR, in particular related to testing.