### PR TITLE
Adapt hirs angle attributes and format

### DIFF
--- a/fiduceo/fcdr/test/writer/templates/hirs_assert.py
+++ b/fiduceo/fcdr/test/writer/templates/hirs_assert.py
@@ -34,12 +34,13 @@ class HIRSAssert(unittest.TestCase):
         self.assertEqual(np.uint16, satellite_zenith_angle.encoding['dtype'])
         self.assertEqual(DefaultData.get_default_fill_value(np.uint16), satellite_zenith_angle.encoding['_FillValue'])
         self.assertEqual(0.01, satellite_zenith_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, satellite_zenith_angle.encoding['add_offset'])
+        self.assertEqual(0, satellite_zenith_angle.encoding['add_offset'])
         if chunking is not None:
             self.assertEqual(chunking, satellite_zenith_angle.encoding['chunksizes'])
         self.assertEqual("platform_zenith_angle", satellite_zenith_angle.attrs["standard_name"])
         self.assertEqual("degree", satellite_zenith_angle.attrs["units"])
         self.assertEqual("longitude latitude", satellite_zenith_angle.attrs["coordinates"])
+        self.assertEqual([0, 180], satellite_zenith_angle.attrs["valid_range"])
 
         solar_zenith_angle = ds.variables["solar_zenith_angle"]
         self.assertEqual((6, 56), solar_zenith_angle.shape)
@@ -47,13 +48,14 @@ class HIRSAssert(unittest.TestCase):
         self.assertEqual(np.uint16, solar_zenith_angle.encoding['dtype'])
         self.assertEqual(DefaultData.get_default_fill_value(np.uint16), solar_zenith_angle.encoding['_FillValue'])
         self.assertEqual(0.01, solar_zenith_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, solar_zenith_angle.encoding['add_offset'])
+        self.assertEqual(0, solar_zenith_angle.encoding['add_offset'])
         if chunking is not None:
             self.assertEqual(chunking, solar_zenith_angle.encoding['chunksizes'])
         self.assertEqual("solar_zenith_angle", solar_zenith_angle.attrs["standard_name"])
         self.assertEqual("solar_zenith_angle", solar_zenith_angle.attrs["orig_name"])
         self.assertEqual("degree", solar_zenith_angle.attrs["units"])
         self.assertEqual("longitude latitude", solar_zenith_angle.attrs["coordinates"])
+        self.assertEqual([0, 180], solar_zenith_angle.attrs["valid_range"])
 
         satellite_azimuth_angle = ds.variables["satellite_azimuth_angle"]
         self.assertEqual((6, 56), satellite_azimuth_angle.shape)
@@ -61,11 +63,12 @@ class HIRSAssert(unittest.TestCase):
         self.assertEqual(np.uint16, satellite_azimuth_angle.encoding['dtype'])
         self.assertEqual(DefaultData.get_default_fill_value(np.uint16), satellite_azimuth_angle.encoding['_FillValue'])
         self.assertEqual(0.01, satellite_azimuth_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, satellite_azimuth_angle.encoding['add_offset'])
+        self.assertEqual(0, satellite_azimuth_angle.encoding['add_offset'])
         if chunking is not None:
             self.assertEqual(chunking, satellite_azimuth_angle.encoding['chunksizes'])
         self.assertEqual("sensor_azimuth_angle", satellite_azimuth_angle.attrs["standard_name"])
-        self.assertEqual("local_azimuth_angle", satellite_azimuth_angle.attrs["long_name"])
+        self.assertEqual([0, 360], satellite_azimuth_angle.attrs["valid_range"])
+        self.assertEqual("clockwise from north", satellite_azimuth_angle.attrs["comment"])
         self.assertEqual("degree", satellite_azimuth_angle.attrs["units"])
         self.assertEqual("longitude latitude", satellite_azimuth_angle.attrs["coordinates"])
 
@@ -75,10 +78,12 @@ class HIRSAssert(unittest.TestCase):
         self.assertEqual(np.uint16, solar_azimuth_angle.encoding['dtype'])
         self.assertEqual(DefaultData.get_default_fill_value(np.uint16), solar_azimuth_angle.encoding['_FillValue'])
         self.assertEqual(0.01, solar_azimuth_angle.encoding['scale_factor'])
-        self.assertEqual(-180.0, solar_azimuth_angle.encoding['add_offset'])
+        self.assertEqual(0, solar_azimuth_angle.encoding['add_offset'])
         if chunking is not None:
             self.assertEqual(chunking, solar_azimuth_angle.encoding['chunksizes'])
         self.assertEqual("solar_azimuth_angle", solar_azimuth_angle.attrs["standard_name"])
+        self.assertEqual([0, 360], solar_azimuth_angle.attrs["valid_range"])
+        self.assertEqual("clockwise from north", solar_azimuth_angle.attrs["comment"])
         self.assertEqual("degree", solar_azimuth_angle.attrs["units"])
         self.assertEqual("longitude latitude", solar_azimuth_angle.attrs["coordinates"])
 

--- a/fiduceo/fcdr/writer/templates/hirs.py
+++ b/fiduceo/fcdr/writer/templates/hirs.py
@@ -131,11 +131,16 @@ class HIRS:
     def add_common_angles(dataset, height):
         chunking_2d = HIRS._ensure_chunking_2d(height)
         dataset["satellite_zenith_angle"] = HIRS._create_geo_angle_variable("platform_zenith_angle", height, chunking=chunking_2d)
+        dataset["satellite_zenith_angle"].variable.attrs["valid_range"] = [0, 180]
         dataset["satellite_azimuth_angle"] = HIRS._create_geo_angle_variable("sensor_azimuth_angle", height, chunking=chunking_2d)
-        dataset["satellite_azimuth_angle"].variable.attrs["long_name"] = "local_azimuth_angle"
+        dataset["satellite_azimuth_angle"].variable.attrs["valid_range"] = [0, 360]
+        dataset["satellite_azimuth_angle"].variable.attrs["comment"] = "clockwise from north"
 
         dataset["solar_zenith_angle"] = HIRS._create_geo_angle_variable("solar_zenith_angle", height, orig_name="solar_zenith_angle", chunking=chunking_2d)
+        dataset["solar_zenith_angle"].variable.attrs["valid_range"] = [0, 180]
         dataset["solar_azimuth_angle"] = HIRS._create_geo_angle_variable("solar_azimuth_angle", height, chunking=chunking_2d)
+        dataset["solar_azimuth_angle"].variable.attrs["valid_range"] = [0, 360]
+        dataset["solar_azimuth_angle"].variable.attrs["comment"] = "clockwise from north"
 
     @staticmethod
     def add_bt_variable(dataset, height):
@@ -643,7 +648,7 @@ class HIRS:
 
         tu.add_units(variable, "degree")
         tu.add_geolocation_attribute(variable)
-        tu.add_encoding(variable, np.uint16, DefaultData.get_default_fill_value(np.uint16), 0.01, -180.0, chunking)
+        tu.add_encoding(variable, np.uint16, DefaultData.get_default_fill_value(np.uint16), 0.01, 0, chunking)
         return variable
 
     @staticmethod


### PR DESCRIPTION
HIRS angle attributes need to define what we mean by azimuth angles.

Make some other changes as well, for consistency and clarity purposes.